### PR TITLE
Add Foojay toolchains plugin to settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "Motmaen Bash"
 include(":app")
  


### PR DESCRIPTION
The project uses Java toolchains and targets Java 8, but it doesn't apply the plugin that lets Gradle download the required JDK automatically. This causes the build to fail on systems that don't have Java 8 installed manually.

This PR adds the missing foojay-resolver-convention plugin so Gradle can fetch Java 8 automatically and the build works out of the box.