### PR TITLE
Fix crash when rendering app icons by safely converting Drawable to Bitmap

### DIFF
--- a/app/src/main/java/nu/milad/motmaenbash/ui/screens/AppScanScreen.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/ui/screens/AppScanScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -71,6 +70,7 @@ import nu.milad.motmaenbash.ui.theme.GreyDark
 import nu.milad.motmaenbash.ui.theme.MotmaenBashTheme
 import nu.milad.motmaenbash.ui.theme.Red
 import nu.milad.motmaenbash.utils.PackageUtils
+import nu.milad.motmaenbash.utils.toSafeBitmap
 import nu.milad.motmaenbash.viewmodels.AppScanViewModel
 import nu.milad.motmaenbash.viewmodels.ScanState
 
@@ -226,7 +226,7 @@ fun SuspiciousAppItem(app: App) {
         // Display app icon if available
         app.appIcon?.let { icon ->
             Image(
-                bitmap = icon.toBitmap().asImageBitmap(),
+                bitmap = icon.toSafeBitmap(size = 96).asImageBitmap(),
                 contentDescription = app.appName,
                 contentScale = ContentScale.Fit,
                 modifier = Modifier
@@ -324,7 +324,7 @@ fun AnimatedAppIcon(app: App) {
     ) {
         app.appIcon?.let { icon ->
             Image(
-                bitmap = icon.toBitmap().asImageBitmap(),
+                bitmap = icon.toSafeBitmap(size = 96).asImageBitmap(),
                 contentDescription = app.appName,
                 contentScale = ContentScale.Fit,
                 modifier = Modifier

--- a/app/src/main/java/nu/milad/motmaenbash/utils/BitmapUtils.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/utils/BitmapUtils.kt
@@ -1,0 +1,14 @@
+package nu.milad.motmaenbash.utils
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.Drawable
+import androidx.core.graphics.createBitmap
+
+fun Drawable.toSafeBitmap(size: Int = 96): Bitmap {
+    val bitmap = createBitmap(size, size)
+    val canvas = Canvas(bitmap)
+    this.setBounds(0, 0, canvas.width, canvas.height)
+    this.draw(canvas)
+    return bitmap
+}


### PR DESCRIPTION
On some devices, the app crashes when rendering certain app icons in the AppScanScreen. The crash is caused by attempting to convert incompatible drawables (such as AdaptiveIconDrawable or drawables with undefined size) to Bitmap using Drawable.toBitmap(). This results in runtime exceptions such as:
java.lang.RuntimeException: Canvas: trying to draw too large(284799376bytes) bitmap.


### Solution

Replaced direct calls to Drawable.toBitmap() with a custom utility function Drawable.toSafeBitmap(size) which safely creates a Bitmap canvas and draws the Drawable onto it with controlled dimensions. This:
- Prevents crashes due to missing bounds or recycled bitmaps.
- Ensures icons are rendered with consistently high quality across devices and screen sizes.