### PR TITLE
Detect icon-hiding adware in the app scan

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+    <uses-permission
+        android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"

--- a/app/src/main/java/nu/milad/motmaenbash/models/Alert.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/models/Alert.kt
@@ -37,7 +37,8 @@ data class Alert(
         SMS_NEUTRAL(5),
         APP_FLAGGED(6),
         URL_FLAGGED(7),
-        APP_RISKY_INSTALL(8);
+        APP_RISKY_INSTALL(8),
+        APP_HIDDEN(9);
 
 
         companion object {

--- a/app/src/main/java/nu/milad/motmaenbash/models/AppThreatType.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/models/AppThreatType.kt
@@ -2,5 +2,7 @@ package nu.milad.motmaenbash.models
 
 enum class AppThreatType {
     MALWARE,
-    RISKY_PERMISSIONS
+    RISKY_PERMISSIONS,
+    HIDDEN_APP,
+    DISABLED_APP
 }

--- a/app/src/main/java/nu/milad/motmaenbash/receivers/AppInstallReceiver.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/receivers/AppInstallReceiver.kt
@@ -12,6 +12,7 @@ import nu.milad.motmaenbash.models.Alert
 import nu.milad.motmaenbash.models.AppThreatType
 import nu.milad.motmaenbash.utils.AlertUtils
 import nu.milad.motmaenbash.utils.DatabaseHelper
+import nu.milad.motmaenbash.utils.HiddenAppDetector
 import nu.milad.motmaenbash.utils.PackageUtils
 import nu.milad.motmaenbash.utils.PermissionAnalyzer
 
@@ -65,9 +66,13 @@ class AppInstallReceiver : BroadcastReceiver() {
                 val app = PackageUtils.getAppInfo(context, packageName) ?: return@launch
                 val dbHelper = DatabaseHelper(context)
 
+                val hiddenAppResult = HiddenAppDetector.analyze(context, packageName)
+
                 val threatType = when {
                     dbHelper.isAppFlagged(packageName, app.apkHash, app.sighHash) ->
                         AppThreatType.MALWARE
+
+                    hiddenAppResult.isHidden -> AppThreatType.HIDDEN_APP
 
                     !PackageUtils.isFromTrustedSource(context, app.installSource) &&
                             !dbHelper.isTrustedSideloadApp(packageName, app.sighHash) -> {
@@ -122,6 +127,19 @@ class AppInstallReceiver : BroadcastReceiver() {
                                     param3 = param3
                                 )
                             }
+
+                            AppThreatType.HIDDEN_APP -> {
+                                AlertUtils.showAlert(
+                                    context = context,
+                                    alertType = Alert.AlertType.APP_HIDDEN,
+                                    alertLevel = Alert.AlertLevel.WARNING,
+                                    param1 = packageName,
+                                    param2 = app.appName,
+                                    param3 = hiddenAppResult.reasons.joinToString("\n")
+                                )
+                            }
+
+                            AppThreatType.DISABLED_APP -> Unit
                         }
 
                     }

--- a/app/src/main/java/nu/milad/motmaenbash/ui/activities/AlertHandlerActivity.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/ui/activities/AlertHandlerActivity.kt
@@ -327,6 +327,13 @@ fun AlertDialog(
                                 AppAlertContent(context, alert.param1, alert.param2, alert.param3)
                             }
 
+                            Alert.AlertType.APP_HIDDEN -> {
+                                AppAlertContent(
+                                    context, alert.param1, alert.param2, alert.param3,
+                                    descriptionTitle = "نشانه‌های مشکوک:"
+                                )
+                            }
+
                             else -> {
                                 DefaultActionButton(onDismiss)
                             }
@@ -351,7 +358,7 @@ fun AlertDialog(
                     }
 
 
-                    if (alert.type == Alert.AlertType.APP_FLAGGED || alert.type == Alert.AlertType.APP_RISKY_INSTALL) {
+                    if (alert.type == Alert.AlertType.APP_FLAGGED || alert.type == Alert.AlertType.APP_RISKY_INSTALL || alert.type == Alert.AlertType.APP_HIDDEN) {
                         Spacer(modifier = Modifier.height(8.dp))
 
 
@@ -463,7 +470,8 @@ private fun AppAlertContent(
     context: Context,
     packageName: String,
     appName: String?,
-    permissionCombinationDescription: String?
+    permissionCombinationDescription: String?,
+    descriptionTitle: String = "ترکیب دسترسی‌های حساس:"
 ) {
     val appInfo = runCatching {
         context.packageManager.getApplicationInfo(packageName, 0)
@@ -476,7 +484,8 @@ private fun AppAlertContent(
         if (descriptions.isNotEmpty()) {
             ExpandablePermissionContent(
                 descriptions = descriptions,
-                modifier = Modifier.padding(4.dp)
+                modifier = Modifier.padding(4.dp),
+                title = descriptionTitle
             )
         }
     }
@@ -562,7 +571,8 @@ private fun DefaultActionButton(onDismiss: () -> Unit) {
 private fun AlertFooter(alertType: Alert.AlertType) {
     val protectionType = when (alertType) {
         in SMS_ALERT_TYPES -> "سپر پیامک"
-        Alert.AlertType.APP_FLAGGED, Alert.AlertType.APP_RISKY_INSTALL -> "سپر برنامه"
+        Alert.AlertType.APP_FLAGGED, Alert.AlertType.APP_RISKY_INSTALL,
+        Alert.AlertType.APP_HIDDEN -> "سپر برنامه"
         else -> "سپر امنیتی"
     }
 
@@ -625,6 +635,7 @@ fun createAlertFromType(
         Alert.AlertType.APP_FLAGGED -> "com.malicious.app" to "نام برنامه مخرب"
         Alert.AlertType.URL_FLAGGED -> "https://malicious-site.com" to "این آدرس مشکوک است."
         Alert.AlertType.APP_RISKY_INSTALL -> "com.malicious.app" to "نام برنامه مخرب"
+        Alert.AlertType.APP_HIDDEN -> "com.hidden.app" to "برنامه مخفی"
 
     }
 
@@ -638,6 +649,7 @@ fun createAlertFromType(
         Alert.AlertType.APP_FLAGGED -> Alert.AlertLevel.ALERT
         Alert.AlertType.URL_FLAGGED -> Alert.AlertLevel.ALERT
         Alert.AlertType.APP_RISKY_INSTALL -> Alert.AlertLevel.WARNING
+        Alert.AlertType.APP_HIDDEN -> Alert.AlertLevel.WARNING
 
     }
 

--- a/app/src/main/java/nu/milad/motmaenbash/ui/components/ExpandablePermissionContent.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/ui/components/ExpandablePermissionContent.kt
@@ -46,13 +46,14 @@ import nu.milad.motmaenbash.utils.NumberUtils
 fun ExpandablePermissionContent(
     descriptions: List<String>,
     modifier: Modifier = Modifier,
-    maxVisibleItems: Int = 5
+    maxVisibleItems: Int = 5,
+    title: String = "ترکیب دسترسی‌های حساس:"
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 
     Column(modifier = modifier) {
         Text(
-            text = "ترکیب دسترسی‌های حساس:",
+            text = title,
             fontSize = 13.sp,
             fontWeight = Bold,
             modifier = Modifier.padding(horizontal = 4.dp)

--- a/app/src/main/java/nu/milad/motmaenbash/ui/screens/AppScanScreen.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/ui/screens/AppScanScreen.kt
@@ -85,12 +85,15 @@ import nu.milad.motmaenbash.ui.components.Divider
 import nu.milad.motmaenbash.ui.theme.GreyDark
 import nu.milad.motmaenbash.ui.theme.GreyMiddle
 import nu.milad.motmaenbash.ui.theme.MotmaenBashTheme
+import nu.milad.motmaenbash.ui.theme.Orange
 import nu.milad.motmaenbash.ui.theme.Red
 import nu.milad.motmaenbash.ui.theme.YellowDark
 import nu.milad.motmaenbash.utils.AlertUtils.getAlertContent
+import nu.milad.motmaenbash.utils.HiddenAppDetector
 import nu.milad.motmaenbash.utils.NumberUtils
 import nu.milad.motmaenbash.utils.PackageUtils
 import nu.milad.motmaenbash.utils.PermissionAnalyzer
+import nu.milad.motmaenbash.utils.UsageStatsHelper
 import nu.milad.motmaenbash.utils.parseBoldTags
 import nu.milad.motmaenbash.utils.toSafeBitmap
 import nu.milad.motmaenbash.viewmodels.AppScanViewModel
@@ -254,6 +257,16 @@ private fun AppSectionView(
                 section.apps.forEachIndexed { index, app ->
                     when (section.appItemType) {
                         AppThreatType.MALWARE -> MalwareAppItem(
+                            app = app,
+                            viewModel = viewModel
+                        )
+
+                        AppThreatType.HIDDEN_APP -> HiddenAppItem(
+                            app = app,
+                            viewModel = viewModel
+                        )
+
+                        AppThreatType.DISABLED_APP -> DisabledAppItem(
                             app = app,
                             viewModel = viewModel
                         )
@@ -663,6 +676,255 @@ fun RiskyPermissionAppItem(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun HiddenAppItem(
+    app: App,
+    viewModel: AppScanViewModel
+) {
+    val context = LocalContext.current
+    val uninstalledApps by viewModel.uninstalledApps.collectAsState()
+    val isUninstalled = app.packageName in uninstalledApps
+
+    val uninstallLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val appName = result.data?.getStringExtra("APP_NAME") ?: app.appName
+        if (result.resultCode == Activity.RESULT_OK) {
+            Toast.makeText(context, "برنامه '$appName' با موفقیت حذف شد", Toast.LENGTH_SHORT)
+                .show()
+            viewModel.markAppAsUninstalled(app.packageName)
+        } else {
+            Toast.makeText(context, "حذف برنامه '$appName' لغو شد", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun showAppDetails() {
+        val usage = UsageStatsHelper.getUsage(context, app.packageName)
+        val reasons = HiddenAppDetector
+            .analyze(context, app.packageName, usage?.foregroundLaunchCount)
+            .reasons.toMutableList()
+        usage?.let { UsageStatsHelper.describe(it).takeIf { d -> d.isNotBlank() }?.let(reasons::add) }
+        val param3 = reasons.joinToString("\n")
+
+        val (alertTitle, alertSummary, alertContent) = getAlertContent(Alert.AlertType.APP_HIDDEN)
+
+        val intent = Intent(context, AlertHandlerActivity::class.java).apply {
+            putExtra(
+                AlertHandlerActivity.EXTRA_ALERT, Alert(
+                    type = Alert.AlertType.APP_HIDDEN,
+                    level = Alert.AlertLevel.WARNING,
+                    title = alertTitle,
+                    summary = alertSummary,
+                    content = alertContent,
+                    param1 = app.packageName,
+                    param2 = app.appName,
+                    param3 = param3
+                )
+            )
+
+            putExtra(AlertHandlerActivity.EXTRA_IS_INFO_ONLY, true)
+        }
+        context.startActivity(intent)
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp, horizontal = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        app.appIcon?.let { icon ->
+            Image(
+                painter = rememberAsyncImagePainter(model = icon),
+                contentDescription = app.appName,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = app.appName,
+                style = typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Text(
+                text = app.packageName,
+                color = GreyMiddle,
+                fontSize = 12.sp,
+                textAlign = TextAlign.Start,
+                maxLines = 1,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .basicMarquee()
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Column(horizontalAlignment = Alignment.End) {
+
+            CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+                Button(
+                    onClick = {
+                        val intent = PackageUtils.uninstallApp(app.packageName)
+                        uninstallLauncher.launch(intent)
+                    },
+                    modifier = Modifier
+                        .heightIn(min = 36.dp),
+
+                    enabled = !isUninstalled,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (isUninstalled) Color.Gray else Orange,
+                        disabledContainerColor = Color.Gray,
+                        disabledContentColor = Color.White
+                    ),
+
+                    contentPadding = PaddingValues(horizontal = 12.dp)
+
+                ) {
+                    Text(
+                        text = if (isUninstalled) "حذف شد" else "حذف برنامه",
+                        fontSize = 12.sp,
+                    )
+                }
+            }
+
+            if (!isUninstalled) {
+                Spacer(modifier = Modifier.height(8.dp))
+
+                CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+                    Button(
+                        onClick = { showAppDetails() },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = GreyMiddle.copy(alpha = 0.1f),
+                            contentColor = GreyMiddle
+                        ),
+                        modifier = Modifier
+                            .heightIn(min = 28.dp),
+
+
+                        contentPadding = PaddingValues(horizontal = 12.dp)
+
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Info,
+                            contentDescription = "اطلاعات بیشتر",
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "جزییات",
+                            fontSize = 10.sp,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DisabledAppItem(
+    app: App,
+    viewModel: AppScanViewModel
+) {
+    val context = LocalContext.current
+    val uninstalledApps by viewModel.uninstalledApps.collectAsState()
+    val isUninstalled = app.packageName in uninstalledApps
+
+    val uninstallLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val appName = result.data?.getStringExtra("APP_NAME") ?: app.appName
+        if (result.resultCode == Activity.RESULT_OK) {
+            Toast.makeText(context, "برنامه '$appName' با موفقیت حذف شد", Toast.LENGTH_SHORT)
+                .show()
+            viewModel.markAppAsUninstalled(app.packageName)
+        } else {
+            Toast.makeText(context, "حذف برنامه '$appName' لغو شد", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp, horizontal = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        app.appIcon?.let { icon ->
+            Image(
+                painter = rememberAsyncImagePainter(model = icon),
+                contentDescription = app.appName,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = app.appName,
+                style = typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Text(
+                text = app.packageName,
+                color = GreyMiddle,
+                fontSize = 12.sp,
+                textAlign = TextAlign.Start,
+                maxLines = 1,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .basicMarquee()
+            )
+
+            Text(
+                text = "غیرفعال شده روی دستگاه",
+                color = GreyMiddle,
+                fontSize = 11.sp,
+            )
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+            Button(
+                onClick = {
+                    val intent = PackageUtils.uninstallApp(app.packageName)
+                    uninstallLauncher.launch(intent)
+                },
+                modifier = Modifier.heightIn(min = 36.dp),
+                enabled = !isUninstalled,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (isUninstalled) Color.Gray else GreyMiddle,
+                    disabledContainerColor = Color.Gray,
+                    disabledContentColor = Color.White
+                ),
+                contentPadding = PaddingValues(horizontal = 12.dp)
+            ) {
+                Text(
+                    text = if (isUninstalled) "حذف شد" else "حذف برنامه",
+                    fontSize = 12.sp,
+                )
             }
         }
     }

--- a/app/src/main/java/nu/milad/motmaenbash/utils/AlertUtils.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/utils/AlertUtils.kt
@@ -190,6 +190,12 @@ object AlertUtils {
                         " در غیر این صورت چنین الگوهایی معمولا در <b>بدافزارها</b> دیده می‌شود و توصیه می‌شود در صورت عدم اطمینان از منبع نصب، آن را سریع حذف کنید."
             )
 
+            Alert.AlertType.APP_HIDDEN -> Triple(
+                "برنامه مخفی شناسایی شد",
+                "این برنامه آیکون خود را پنهان کرده است.",
+                "این برنامه <b>آیکونی ندارد</b> تا پیدا یا حذف نشود، ولی می‌تواند تبلیغ نشان دهد؛ رفتاری رایج در <b>تبلیغ‌افزارها</b>. اگر آن را نصب نکرده‌اید، حذفش کنید."
+            )
+
             Alert.AlertType.URL_FLAGGED -> {
                 val domainOrUrlText =
                     if (isSpecificUrl) "آدرس اینترنتی" else "دامنه اینترنتی"
@@ -238,6 +244,7 @@ object AlertUtils {
 
             Alert.AlertType.SMS_SENDER_FLAGGED -> "پیامک‌های این شماره را با دقت بررسی کنید."
             Alert.AlertType.APP_FLAGGED -> "بدون اجرای برنامه، سریع آن را حذف کنید."
+            Alert.AlertType.APP_HIDDEN -> "اگر این برنامه را نمی‌شناسید، آن را حذف کنید."
 
             Alert.AlertType.URL_FLAGGED -> when (threatType) {
                 Alert.UrlThreatType.PHISHING -> "از باز کردن این لینک خودداری کنید."

--- a/app/src/main/java/nu/milad/motmaenbash/utils/DisabledAppDetector.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/utils/DisabledAppDetector.kt
@@ -1,0 +1,20 @@
+package nu.milad.motmaenbash.utils
+
+import android.content.Context
+import android.content.pm.PackageManager
+
+object DisabledAppDetector {
+
+    fun isDisabled(context: Context, packageName: String): Boolean {
+        return try {
+            when (context.packageManager.getApplicationEnabledSetting(packageName)) {
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER -> true
+
+                else -> false
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/nu/milad/motmaenbash/utils/HiddenAppDetector.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/utils/HiddenAppDetector.kt
@@ -1,0 +1,99 @@
+package nu.milad.motmaenbash.utils
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+
+object HiddenAppDetector {
+
+    private const val TAG = "HiddenAppDetector"
+
+    private const val SELF_LAUNCH_THRESHOLD = 30
+
+    data class Result(
+        val isHidden: Boolean,
+        val reasons: List<String>
+    )
+
+    private val NOT_HIDDEN = Result(isHidden = false, reasons = emptyList())
+
+    fun analyze(context: Context, packageName: String, selfLaunchCount: Int? = null): Result {
+        val pm = context.packageManager
+
+        try {
+            val appEnabled = pm.getApplicationEnabledSetting(packageName)
+            if (appEnabled == PackageManager.COMPONENT_ENABLED_STATE_DISABLED ||
+                appEnabled == PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER
+            ) {
+                return NOT_HIDDEN
+            }
+
+            if (pm.checkSignatures(packageName, "android") == PackageManager.SIGNATURE_MATCH) {
+                return NOT_HIDDEN
+            }
+
+            val launcherIntent = Intent(Intent.ACTION_MAIN).apply {
+                addCategory(Intent.CATEGORY_LAUNCHER)
+                setPackage(packageName)
+            }
+            @Suppress("DEPRECATION")
+            val launchers = pm.queryIntentActivities(
+                launcherIntent,
+                PackageManager.GET_DISABLED_COMPONENTS
+            )
+
+            var hasEnabledLauncher = false
+            var hasBlankedDisabledLauncher = false
+            for (resolveInfo in launchers) {
+                val activity = resolveInfo.activityInfo ?: continue
+                val component = android.content.ComponentName(activity.packageName, activity.name)
+                val enabled = when (pm.getComponentEnabledSetting(component)) {
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED -> true
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED_UNTIL_USED -> false
+                    else -> activity.enabled
+                }
+                if (enabled) {
+                    hasEnabledLauncher = true
+                    break
+                }
+                val hasOwnLabel = activity.labelRes != 0 ||
+                        !activity.nonLocalizedLabel.isNullOrBlank()
+                if (!hasOwnLabel) hasBlankedDisabledLauncher = true
+            }
+
+            if (hasEnabledLauncher) return NOT_HIDDEN
+
+            val structurallyHidden = hasBlankedDisabledLauncher
+            val selfLaunching = selfLaunchCount != null && selfLaunchCount >= SELF_LAUNCH_THRESHOLD
+
+            if (!structurallyHidden && !selfLaunching) return NOT_HIDDEN
+
+            val reasons = mutableListOf<String>()
+            if (structurallyHidden) {
+                reasons.add("آیکون خود را پنهان کرده است")
+            }
+            if (selfLaunching) {
+                reasons.add(
+                    "${NumberUtils.toPersianNumbers(selfLaunchCount.toString())} بار خودبه‌خود در پیش‌زمینه باز شده"
+                )
+            }
+
+            val permissions = pm.getPackageInfo(
+                packageName, PackageManager.GET_PERMISSIONS
+            ).requestedPermissions?.toHashSet() ?: hashSetOf()
+            if ("android.permission.RECEIVE_BOOT_COMPLETED" in permissions &&
+                "android.permission.FOREGROUND_SERVICE" in permissions
+            ) {
+                reasons.add("اجرای خودکار و فعالیت در پس‌زمینه")
+            }
+
+            return Result(isHidden = true, reasons = reasons)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not analyze $packageName", e)
+            return NOT_HIDDEN
+        }
+    }
+}

--- a/app/src/main/java/nu/milad/motmaenbash/utils/UsageStatsHelper.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/utils/UsageStatsHelper.kt
@@ -1,0 +1,114 @@
+package nu.milad.motmaenbash.utils
+
+import android.app.AppOpsManager
+import android.app.usage.UsageEvents
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Process
+import android.provider.Settings
+
+object UsageStatsHelper {
+
+    private const val WINDOW_MS = 7L * 24 * 60 * 60 * 1000
+
+    data class UsageInfo(
+        val lastTimeUsed: Long,
+        val foregroundMs: Long,
+        val foregroundServiceMs: Long,
+        val foregroundLaunchCount: Int
+    )
+
+    fun hasUsageAccess(context: Context): Boolean {
+        return try {
+            val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+            val uid = Process.myUid()
+            val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                appOps.unsafeCheckOpNoThrow(
+                    AppOpsManager.OPSTR_GET_USAGE_STATS, uid, context.packageName
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                appOps.checkOpNoThrow(
+                    AppOpsManager.OPSTR_GET_USAGE_STATS, uid, context.packageName
+                )
+            }
+            mode == AppOpsManager.MODE_ALLOWED
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    fun usageAccessSettingsIntent(): Intent =
+        Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    fun getUsage(
+        context: Context,
+        packageName: String,
+        now: Long = System.currentTimeMillis()
+    ): UsageInfo? {
+        if (!hasUsageAccess(context)) return null
+        return try {
+            val usm = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
+            val begin = now - WINDOW_MS
+
+            val stats = usm.queryAndAggregateUsageStats(begin, now)[packageName]
+            val lastUsed = stats?.lastTimeUsed ?: 0L
+            val foreground = stats?.totalTimeInForeground ?: 0L
+            val foregroundService = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                stats?.totalTimeForegroundServiceUsed ?: 0L
+            } else 0L
+
+            var launches = 0
+            val events = usm.queryEvents(begin, now)
+            val event = UsageEvents.Event()
+            while (events.hasNextEvent()) {
+                events.getNextEvent(event)
+                @Suppress("DEPRECATION")
+                if (event.packageName == packageName &&
+                    event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND
+                ) {
+                    launches++
+                }
+            }
+            UsageInfo(lastUsed, foreground, foregroundService, launches)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun getForegroundLaunchCounts(
+        context: Context,
+        now: Long = System.currentTimeMillis()
+    ): Map<String, Int> {
+        if (!hasUsageAccess(context)) return emptyMap()
+        return try {
+            val usm = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
+            val events = usm.queryEvents(now - WINDOW_MS, now)
+            val counts = HashMap<String, Int>()
+            val event = UsageEvents.Event()
+            while (events.hasNextEvent()) {
+                events.getNextEvent(event)
+                @Suppress("DEPRECATION")
+                if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
+                    counts[event.packageName] = (counts[event.packageName] ?: 0) + 1
+                }
+            }
+            counts
+        } catch (e: Exception) {
+            emptyMap()
+        }
+    }
+
+    fun describe(usage: UsageInfo): String {
+        val parts = mutableListOf<String>()
+        if (usage.lastTimeUsed > 0) {
+            parts.add("آخرین اجرا ${DateUtils.timeAgo(usage.lastTimeUsed)}")
+        }
+        if (usage.foregroundLaunchCount > 0) {
+            parts.add("${NumberUtils.toPersianNumbers(usage.foregroundLaunchCount.toString())} بار در هفته اخیر")
+        }
+        return parts.joinToString("، ")
+    }
+}

--- a/app/src/main/java/nu/milad/motmaenbash/viewmodels/AppScanViewModel.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/viewmodels/AppScanViewModel.kt
@@ -3,11 +3,13 @@ package nu.milad.motmaenbash.viewmodels
 import android.app.Application
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AdminPanelSettings
+import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.GppBad
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.TrackChanges
+import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -31,10 +33,14 @@ import nu.milad.motmaenbash.ui.theme.ColorPrimary
 import nu.milad.motmaenbash.ui.theme.Green
 import nu.milad.motmaenbash.ui.theme.Grey
 import nu.milad.motmaenbash.ui.theme.GreyMiddle
+import nu.milad.motmaenbash.ui.theme.Orange
 import nu.milad.motmaenbash.ui.theme.Red
 import nu.milad.motmaenbash.ui.theme.YellowDark
 import nu.milad.motmaenbash.utils.AudioHelper
 import nu.milad.motmaenbash.utils.DatabaseHelper
+import nu.milad.motmaenbash.utils.DisabledAppDetector
+import nu.milad.motmaenbash.utils.HiddenAppDetector
+import nu.milad.motmaenbash.utils.UsageStatsHelper
 import nu.milad.motmaenbash.utils.NumberUtils
 import nu.milad.motmaenbash.utils.PackageUtils
 import nu.milad.motmaenbash.utils.PackageUtils.getAppInfo
@@ -110,6 +116,8 @@ open class AppScanViewModel(private val context: Application) : AndroidViewModel
             try {
                 val nonSystemAppPackages = scanUtils.getNonSystemInstalledPackages()
                 val totalApps = nonSystemAppPackages.size
+
+                val foregroundCounts = UsageStatsHelper.getForegroundLaunchCounts(context)
                 val detectSuspiciousAppsJobs =
                     nonSystemAppPackages.mapIndexed { index, packageInfo ->
                         async {
@@ -134,6 +142,17 @@ open class AppScanViewModel(private val context: Application) : AndroidViewModel
                                         app.apkHash,
                                         app.sighHash
                                     ) -> AppThreatType.MALWARE
+
+                                    HiddenAppDetector.analyze(
+                                        context,
+                                        app.packageName,
+                                        foregroundCounts[app.packageName]
+                                    ).isHidden -> AppThreatType.HIDDEN_APP
+
+                                    DisabledAppDetector.isDisabled(
+                                        context,
+                                        app.packageName
+                                    ) -> AppThreatType.DISABLED_APP
 
                                     !PackageUtils.isFromTrustedSource(context, app.installSource) &&
                                             !databaseHelper.isTrustedSideloadApp(
@@ -241,6 +260,8 @@ open class AppScanViewModel(private val context: Application) : AndroidViewModel
 @Composable
 fun createAppSections(suspiciousApps: List<App>): List<SectionConfig> {
     val malwareApps = suspiciousApps.filter { it.threatType == AppThreatType.MALWARE }
+    val hiddenApps = suspiciousApps.filter { it.threatType == AppThreatType.HIDDEN_APP }
+    val disabledApps = suspiciousApps.filter { it.threatType == AppThreatType.DISABLED_APP }
     val riskyPermissionApps =
         suspiciousApps.filter { it.threatType == AppThreatType.RISKY_PERMISSIONS }
 
@@ -252,6 +273,25 @@ fun createAppSections(suspiciousApps: List<App>): List<SectionConfig> {
             color = if (malwareApps.isNotEmpty()) Red else GreyMiddle.copy(alpha = 0.5f),
             apps = malwareApps,
             appItemType = AppThreatType.MALWARE
+        ),
+        SectionConfig(
+            title = "برنامه‌های مخفی (بدون آیکون)",
+            subtitle = ("این برنامه‌ها آیکونی در فهرست برنامه‌ها ندارند تا از دید کاربر پنهان بمانند، " +
+                    "اما می‌توانند صفحه‌هایی مانند تبلیغ را نمایش دهند. این رفتار رایج <b>تبلیغ‌افزارها</b> است. " +
+                    "اگر برنامه‌ای را در این فهرست نمی‌شناسید، آن را حذف کنید.").takeIf { hiddenApps.isNotEmpty() },
+            icon = Icons.Outlined.VisibilityOff,
+            color = if (hiddenApps.isNotEmpty()) Orange else GreyMiddle.copy(alpha = 0.5f),
+            apps = hiddenApps,
+            appItemType = AppThreatType.HIDDEN_APP
+        ),
+        SectionConfig(
+            title = "برنامه‌های غیرفعال (قابل حذف)",
+            subtitle = ("این برنامه‌ها روی دستگاه غیرفعال شده‌اند، بنابراین اجرا نمی‌شوند و آیکونی ندارند، " +
+                    "اما همچنان نصب هستند. اگر به آن‌ها نیازی ندارید، می‌توانید کاملا حذفشان کنید.").takeIf { disabledApps.isNotEmpty() },
+            icon = Icons.Outlined.Block,
+            color = if (disabledApps.isNotEmpty()) GreyMiddle else GreyMiddle.copy(alpha = 0.5f),
+            apps = disabledApps,
+            appItemType = AppThreatType.DISABLED_APP
         ),
         SectionConfig(
             title = "برنامه‌های نیاز به بررسی بیشتر",
@@ -321,6 +361,8 @@ object EmptyStateHelper {
             scanState == ScanState.COMPLETED_SUCCESSFULLY -> {
                 when (appItemType) {
                     AppThreatType.MALWARE -> "بدافزاری شناسایی نشد"
+                    AppThreatType.HIDDEN_APP -> "برنامه مخفی‌ای شناسایی نشد"
+                    AppThreatType.DISABLED_APP -> "برنامه غیرفعالی یافت نشد"
                     AppThreatType.RISKY_PERMISSIONS -> "برنامه‌ای یافت نشد"
                 }
             }


### PR DESCRIPTION
## What this adds

A new section in the app scan that detects **stealth adware** apps that hide their launcher icon and keep launching themselves from the background to show ads (the technique behind current fake-cleaner / fake-game apps). It also lists fully **disabled leftover apps** separately so they can be removed.

> 
<img width="1080" height="2400" alt="image_2026-06-13_00-10-34" src="https://github.com/user-attachments/assets/375def4d-d6f0-49b8-bea7-956c1897cbdf" />


## How it decides

Only apps the user **can't launch** (no visible launcher icon) are judged; an app with a normal icon is left alone, because its foregrounds can't be told apart from user launches. Within that group, an app is flagged if **either**:

- **(A) Structural**: it declares a launcher activity, has disabled it, and stripped its label (the icon-blanking trick); or
- **(B) Behavioral**: it foregrounded itself far more than any legitimately indirectly-launched app would (read from `UsageStatsManager`).

Apps the user disabled and OEM/platform-signed preloads are excluded by comparing the signing certificate against the device platform certificate, not by any vendor/package allowlist.

> 
<img width="1080" height="2400" alt="image_2026-06-13_00-10-51" src="https://github.com/user-attachments/assets/6bccd7ff-427c-47b1-989d-08d351344333" />


## Install-time detection

The same check runs on install through the existing `AppInstallReceiver`, so a hidden app is flagged the moment it is (re)installed:

> 
<img width="788" height="1280" alt="photo_2026-06-13_00-30-41" src="https://github.com/user-attachments/assets/84f36319-4b47-4a8c-83c4-1d00ee19740a" />


## Implementation notes

- New `AppThreatType.HIDDEN_APP` / `DISABLED_APP`, plus `HiddenAppDetector`, `DisabledAppDetector`, `UsageStatsHelper`.
- Run history (last run + weekly self-launch count) shows only in the per-app details dialog. It needs **Usage Access** — a special access the user enables in Settings (not a runtime permission) — and the behavioral path stays dormant (falls back to the structural path) until granted.
- **Additive & safe**: shared alert components gained a default `title` parameter, so existing SMS / URL / app alerts render unchanged; existing enum values keep their numbers (alert-history safe).
