### PR TITLE
قابلیت کپی کردن متن پیامک توی کلیپ بورد

### DIFF
--- a/app/src/main/java/nu/milad/motmaenbash/ui/activities/AlertHandlerActivity.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/ui/activities/AlertHandlerActivity.kt
@@ -392,49 +392,41 @@ fun AlertDialog(
 fun SmsAlertContent(
     context: Context,
     alert: Alert,
-
-    ) {
+) {
     val sender: String = alert.param1
     val messageText: String? = alert.param2
+    val clipboardManager = LocalClipboardManager.current
 
     Text(
         text = buildAnnotatedString {
             append("فرستنده: ")
             withStyle(style = SpanStyle(color = if (alert.type == Alert.AlertType.SMS_NEUTRAL) colorScheme.primary else colorScheme.onSurface)) {
-                append("\u200E$sender") // Ensure proper LTR rendering for sender (\u200E is the LTR mark)
+                append("\u200E$sender")
             }
         },
-
         fontSize = 13.sp,
         fontWeight = FontWeight.SemiBold,
         modifier = Modifier
-            .wrapContentSize()
-            .then(
-                if (alert.type == Alert.AlertType.SMS_NEUTRAL) {
-                    Modifier.clickable {
-                        val intent = Intent(Intent.ACTION_VIEW).apply {
-                            data = "sms:$sender".toUri()
-                        }
-                        context.startActivity(intent)
-                        // Close the alert activity after navigating to SMS app
-                        if (context is AlertHandlerActivity) {
-                            context.finishAndRemoveTask()
-                        }
-                    }
-                } else {
-                    Modifier
+            .fillMaxWidth()
+            .clickable(enabled = alert.type == Alert.AlertType.SMS_NEUTRAL) {
+                val intent = Intent(Intent.ACTION_VIEW).apply {
+                    data = "sms:$sender".toUri()
                 }
-            )
+                context.startActivity(intent)
+                    // Close the alert activity after navigating to SMS app
+                if (context is AlertHandlerActivity) {
+                    context.finishAndRemoveTask()
+                }
+            }
     )
 
     messageText?.let { text ->
-        val clipboardManager = LocalClipboardManager.current
-        
+        val cleanText = text.replace(Regex("\n{3,}"), "\n\n").trim()
         Text(
             text = buildAnnotatedString {
                 append("متن پیامک: ")
                 withStyle(style = SpanStyle(color = colorScheme.primary)) {
-                    append(text.replace(Regex("\n{3,}"), "\n\n").trim())
+                    append(cleanText)
                 }
             },
             fontSize = 13.sp,
@@ -442,13 +434,13 @@ fun SmsAlertContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable {
-                    clipboardManager.setText(AnnotatedString(text))
+                    clipboardManager.setText(AnnotatedString(cleanText))
                     Toast.makeText(context, "متن پیامک کپی شد", Toast.LENGTH_SHORT).show()
                 }
         )
     }
-
 }
+
 
 @Composable
 private fun AppAlertContent(

--- a/app/src/main/java/nu/milad/motmaenbash/ui/activities/AlertHandlerActivity.kt
+++ b/app/src/main/java/nu/milad/motmaenbash/ui/activities/AlertHandlerActivity.kt
@@ -44,7 +44,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -425,35 +427,25 @@ fun SmsAlertContent(
             )
     )
 
-    messageText?.let {
+    messageText?.let { text ->
+        val clipboardManager = LocalClipboardManager.current
+        
         Text(
-            text = "متن پیامک:",
-            color = colorScheme.onSurface,
+            text = buildAnnotatedString {
+                append("متن پیامک: ")
+                withStyle(style = SpanStyle(color = colorScheme.primary)) {
+                    append(text.replace(Regex("\n{3,}"), "\n\n").trim())
+                }
+            },
             fontSize = 13.sp,
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier
                 .fillMaxWidth()
+                .clickable {
+                    clipboardManager.setText(AnnotatedString(text))
+                    Toast.makeText(context, "متن پیامک کپی شد", Toast.LENGTH_SHORT).show()
+                }
         )
-
-        Column(
-            modifier = Modifier
-                .padding(2.dp)
-                .clip(RoundedCornerShape(16.dp)),
-            horizontalAlignment = Alignment.Start
-        ) {
-            SelectionContainer {
-                Text(
-                    text = it.replace(Regex("\n{3,}"), "\n\n").trim(),
-                    color = colorScheme.onSurface,
-                    fontSize = 14.sp,
-                    textAlign = TextAlign.Start,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(colorScheme.background)
-                        .padding(8.dp)
-                )
-            }
-        }
     }
 
 }


### PR DESCRIPTION
@miladnouri سلام
شرمنده من بیشتر از مطمئن باش برای همین قابلیت پاپاپ پیام هاش استفاده میکنم واقعا کارو خیلی راحت میکنه😂😭
دسترس پذیری متن پیامک رو برای صفحه خوان ها بهتر کردم چون قبلا دو تا text جداگانه بود یعنی یک بار که سوایپ میکردیم میگفت متن پیامک، یک بار دیگه سوایپ میکردیم متن پیامک رو میخوند.
اما مثل فرستنده درستش کردمش الان کلا تاکبک اینم ی دونه object clickable  میشناسه و میگه متن پیامک: سلام جوجه کبابارو اماده کردی؟ و کلیپ بورد کپی بهش اضافه کردم که وقتی روی متن پیامک کیلیک کنیم کپی بشه توست هم گذاشتم براش
واقعا یکی از آرزو هام این بود که مطمئن باش جاوا بود نه کاتلین من جاوا رو خیلی دوست دارم برای همین ی پروژه ای که جاوا باشه رو خیلی لذت میبرم روش کار کنم اما مطمئن باش به خاطر ارزش های زیاد و قشنگش خیلی زیباست
یکی دوتا پول ریکوعست دیگه هم میزنم برای یکی کردن متن ها برای دسترس پذیری بهتر برای صفحه خوان ها مثلا جای این که بگه تعداد هشدار های شما
بعد ی بار دیگه سوایپ کنیم بگه 0،
باید اینجوری باشه که بگه هشدار های شما: 0
اینجوری سوایپ برای افراد نابینا کمتر میشه
پول ریکوعست میزنم درستش میکنم
اینم کامل کامپایل و تست کردم، هیچ مشکلی وجود نداره اگه خواستید خودتونم ی نگاهی بندازید ولی خیالتون راحت. اگه چیزی نیاز بود تغییری چیزی من در خدمتم
دمتون گرم! ببخشید من خیلی وقت پیش قرار بود روی مطمئن باش کار کنم انقد دیر شد